### PR TITLE
Replace get_marker with get_closest_marker

### DIFF
--- a/pytest_usefixturesif.py
+++ b/pytest_usefixturesif.py
@@ -10,7 +10,7 @@ def pytest_configure(config):
 
 def pytest_runtest_setup(item):
     """Add pytest.markusefixturesif() to py.test"""
-    marker = item.get_marker('usefixturesif')
+    marker = item.get_closest_marker('usefixturesif')
     if marker is not None:
         for info in marker:
             if info.args[0]:


### PR DESCRIPTION
- `4546 &lt;https://github.com/pytest-dev/pytest/issues/4546&gt;`_: Remove ``Node.get_marker(name)`` the return value was not usable for more than a existence check.

Use ``Node.get_closest_marker(name)`` as a replacement.